### PR TITLE
Travis CIからSlackへの通知を追加しました

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - '0.10'
 deploy:
   provider: heroku
   api_key:
@@ -9,3 +9,6 @@ deploy:
     mater: cafeo
   on:
     repo: prototype-cafe/cafeo
+notifications:
+  slack:
+    secure: T/aOSvbKnMZRRmzbshRzMd9t40/zEx/UJUxTNvB8gfSb6l+VLdica3XznDlZcOuB9GlOMVaUXGuV/fUUcaHXH3ecqQ5T5wF93srSl/+O4QLMSj0XYp6Vhnl3VlpEbBzPcuadl7OkzRjJiQDFzZtYnPFfY7rK7TCkXimFR+nTAYk=


### PR DESCRIPTION
## About

Travis CIのビルド結果をSlackに通知するよう、`.travis.yml`を編集しています。
なお、API Tokenはtravisのコマンドでencryptしています。
通知先は#cafeo-developにしました。
## todo
- [x] `travis encrypt "p-cafe:hogehoge(API Token)" --add notifications.slack`
