### PR TITLE
Change source location of hubot-maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hubot-google-translate": "~0.1.0",
     "hubot-help": "~0.1.1",
     "hubot-heroku-keepalive": "0.0.4",
-    "hubot-maps": "0.0.0",
+    "hubot-maps": "git://github.com/wildtree/hubot-maps.git#multibyte",
     "hubot-otsukare-yamero": "git://github.com/prototype-cafe/hubot-otsukare-yamero",
     "hubot-pugme": "~0.1.0",
     "hubot-redis-brain": "0.0.2",


### PR DESCRIPTION
The master of hubot-maps has a bug refering an undefined function[_1],
and a PR is sent for it but it has been ignored for three months[_2].
So I decided to change the source location of hubot-maps.

NOTE:
  [_1] http://nathanielhoag.com/blog/2015/01/02/deploying-a-patched-hubot-maps-script/
  [_2] https://github.com/gkoo/hubot-maps/pull/3
