### PR TITLE
Bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "description": "A simple helpful robot for your Company",
   "dependencies": {
     "coffee-script": "^1.9.1",
-    "hubot": "^2.11.0",
+    "hubot": "^2.11.4",
     "hubot-diagnostics": "0.0.1",
-    "hubot-google-images": "~0.1.1",
+    "hubot-google-images": "~0.1.4",
     "hubot-google-translate": "~0.1.0",
     "hubot-help": "~0.1.1",
     "hubot-heroku-keepalive": "0.0.4",
@@ -20,8 +20,8 @@
     "hubot-rss-reader": "^0.6.5",
     "hubot-rules": "~0.1.0",
     "hubot-scripts": "~2.5.16",
-    "hubot-shipit": "~0.1.1",
-    "hubot-slack": "~3.1.0",
+    "hubot-shipit": "~0.1.2",
+    "hubot-slack": "~3.3.0",
     "hubot-somosan-seppa": "git://github.com/prototype-cafe/hubot-somosan-seppa",
     "hubot-windows-dameOS": "git://github.com/prototype-cafe/hubot-windows-dameOS.git",
     "hubot-youtube": "~0.1.2"


### PR DESCRIPTION
現状のslack用のアダプタは、発言中のURLに括弧をつけてscriptに渡すため、
hubot-rss-reader等が期待通りに動きません。
npm-check-updateコマンドでslackアダプタ含め、依存パッケージを最新化しました。
